### PR TITLE
Remove bindings generation from manifest build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ edgee_world:
 
 setup: edgee_world ## setup development environment
 
-build: 
+build: setup
 	edgee components build
 
 build-no-edgee: setup ## build component

--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/edgee-cloud/example-py-component"
 wit-world-version = "0.4.0"
 
 [component.build]
-command = "uv sync && uv run componentize-py --wit-path wit/ bindings edgee_world && uv run componentize-py --wit-path wit/ --world data-collection componentize dc_component -o dc_component.wasm"
+command = "uv run componentize-py --wit-path wit/ --world data-collection componentize dc_component -o dc_component.wasm"
 output_path = "./dc_component.wasm"
 
 [component.settings.example]


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](https://github.com/edgee-cloud/.github/blob/main/CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](https://github.com/edgee-cloud/.github/blob/main/CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

If you run `uv run componentize-py --wit-path wit/ bindings edgee_world` when the `edgee_world` already exists, the command fails, so it can't be chained in the build command).
